### PR TITLE
Reduce warnings

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/lib/mdns/client.ex
+++ b/lib/mdns/client.ex
@@ -11,13 +11,13 @@ defmodule Mdns.Client do
 
   # Commenting these out as they are not used right now
   # @default_queries [
-  #     %DNS.Query{domain: to_char_list("_services._dns-sd._udp.local"), type: :ptr, class: :in},
-  #     %DNS.Query{domain: to_char_list("_http._tcp.local"), type: :ptr, class: :in},
-  #     %DNS.Query{domain: to_char_list("_googlecast._tcp.local"), type: :ptr, class: :in},
-  #     %DNS.Query{domain: to_char_list("_workstation._tcp.local"), type: :ptr, class: :in},
-  #     %DNS.Query{domain: to_char_list("_sftp-ssh._tcp.local"), type: :ptr, class: :in},
-  #     %DNS.Query{domain: to_char_list("_ssh._tcp.local"), type: :ptr, class: :in},
-  #     %DNS.Query{domain: to_char_list("b._dns-sd._udp.local"), type: :ptr, class: :in},
+  #     %DNS.Query{domain: to_charlist("_services._dns-sd._udp.local"), type: :ptr, class: :in},
+  #     %DNS.Query{domain: to_charlist("_http._tcp.local"), type: :ptr, class: :in},
+  #     %DNS.Query{domain: to_charlist("_googlecast._tcp.local"), type: :ptr, class: :in},
+  #     %DNS.Query{domain: to_charlist("_workstation._tcp.local"), type: :ptr, class: :in},
+  #     %DNS.Query{domain: to_charlist("_sftp-ssh._tcp.local"), type: :ptr, class: :in},
+  #     %DNS.Query{domain: to_charlist("_ssh._tcp.local"), type: :ptr, class: :in},
+  #     %DNS.Query{domain: to_charlist("b._dns-sd._udp.local"), type: :ptr, class: :in},
   # ]
 
   defmodule State do
@@ -78,7 +78,7 @@ defmodule Mdns.Client do
 
   def handle_cast({:query, namespace}, state) do
     packet = %DNS.Record{@query_packet | :qdlist => [
-        %DNS.Query{domain: to_char_list(namespace), type: :ptr, class: :in}
+        %DNS.Query{domain: to_charlist(namespace), type: :ptr, class: :in}
     ]}
     :gen_udp.send(state.udp, @mdns_group, @port, DNS.Record.encode(packet))
     {:noreply,  %State{state | :queries => Enum.uniq([namespace | state.queries])}}
@@ -124,7 +124,7 @@ defmodule Mdns.Client do
   def handle_device({:dns_rr, _d, :txt, _id, _, _, data, _, _, _}, device) do
     %Device{device | :payload => Enum.reduce(data, %{}, fn(kv, acc) ->
       case String.split(to_string(kv), "=", parts: 2) do
-        [k, v] -> Map.put(acc, String.downcase(k), String.strip(v))
+        [k, v] -> Map.put(acc, String.downcase(k), String.trim(v))
         _ -> nil
       end
     end)}

--- a/lib/mdns/server.ex
+++ b/lib/mdns/server.ex
@@ -105,7 +105,7 @@ defmodule Mdns.Server do
                 :ip -> state.ip
                 _ ->
                   case String.valid?(service.data) do
-                    true -> to_char_list(service.data)
+                    true -> to_charlist(service.data)
                     _ -> service.data
                   end
               end
@@ -114,7 +114,7 @@ defmodule Mdns.Server do
                 type: service.type,
                 ttl: service.ttl,
                 data: data,
-                domain: to_char_list(service.domain)
+                domain: to_charlist(service.domain)
             } | answers]
           true -> answers
         end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,6 @@
-%{"dns": {:hex, :dns, "1.0.1", "1d88187fdf564d937cee202949141090707fd0c9d7fcae903a6878ef24ef5d1e", [:mix], [{:socket, "~> 0.3.12", [hex: :socket, repo: "hexpm", optional: false]}], "hexpm"},
-  "earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.16.2", "3b3e210ebcd85a7c76b4e73f85c5640c011d2a0b2f06dcdf5acdb2ae904e5084", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "socket": {:hex, :socket, "0.3.12", "4a6543815136503fee67eff0932da1742fad83f84c49130c854114153cc549a6", [:mix], [], "hexpm"}}
+%{
+  "dns": {:hex, :dns, "1.0.1", "1d88187fdf564d937cee202949141090707fd0c9d7fcae903a6878ef24ef5d1e", [:mix], [{:socket, "~> 0.3.12", [hex: :socket, repo: "hexpm", optional: false]}], "hexpm"},
+  "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.18.2", "993e0a95e9fbb790ac54ea58e700b45b299bd48bc44b4ae0404f28161f37a83e", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "socket": {:hex, :socket, "0.3.12", "4a6543815136503fee67eff0932da1742fad83f84c49130c854114153cc549a6", [:mix], [], "hexpm"},
+}


### PR DESCRIPTION
This fixes most of the warnings produced when compiling the mdns library. I left the GenEvent ones since I didn't know if you had more significant plans than just replacing it with `:gen_event`. 

Fwiw, the test didn't pass for me on `master`, but I'm pretty sure that this change isn't breaking things. I also didn't try hard, so if there's a manual setup step, I certainly missed that.