### PR TITLE
Proper domain resolving when using `Mdns.Client`

### DIFF
--- a/lib/mdns/server.ex
+++ b/lib/mdns/server.ex
@@ -103,7 +103,7 @@ defmodule Mdns.Server do
     Enum.flat_map(record.qdlist, fn %DNS.Query{} = q ->
       Enum.reduce(state.services, [], fn service, answers ->
         cond do
-          service.domain == to_string(q.domain) ->
+          service.type == :a || service.domain == to_string(q.domain) ->
             data =
               case service.data do
                 :ip ->


### PR DESCRIPTION
This PR fixes empty domain field when you try to discover devices that using `Mdns.Server` 