### PR TITLE
Reuse port support for linux and mac

### DIFF
--- a/lib/mdns/client.ex
+++ b/lib/mdns/client.ex
@@ -3,9 +3,6 @@ defmodule Mdns.Client do
   require Logger
   alias Mdns.Utilities.Network
 
-  @mdns_group {224, 0, 0, 251}
-  @port Application.get_env(:mdns, :port, 5353)
-
   @query_packet %DNS.Record{
     header: %DNS.Header{},
     qdlist: []
@@ -52,14 +49,14 @@ defmodule Mdns.Client do
       active: true,
       ip: {0, 0, 0, 0},
       ifaddr: {0, 0, 0, 0},
-      add_membership: {@mdns_group, {0, 0, 0, 0}},
+      add_membership: {Network.mdns_group, {0, 0, 0, 0}},
       multicast_if: {0, 0, 0, 0},
       multicast_loop: true,
       multicast_ttl: 32,
       reuseaddr: true
     ] ++ Network.reuse_port()
 
-    {:ok, udp} = :gen_udp.open(@port, udp_options)
+    {:ok, udp} = :gen_udp.open(Network.mdns_port, udp_options)
     {:reply, :ok, %State{state | udp: udp}}
   end
 
@@ -76,7 +73,7 @@ defmodule Mdns.Client do
     }
 
     p = DNS.Record.encode(packet)
-    :gen_udp.send(state.udp, @mdns_group, @port, p)
+    :gen_udp.send(state.udp, Network.mdns_group, Network.mdns_port, p)
     {:noreply, %State{state | :queries => Enum.uniq([namespace | state.queries])}}
   end
 

--- a/lib/mdns/client.ex
+++ b/lib/mdns/client.ex
@@ -1,6 +1,7 @@
 defmodule Mdns.Client do
   use GenServer
   require Logger
+  alias Mdns.Utilities.Network
 
   @mdns_group {224, 0, 0, 251}
   @port Application.get_env(:mdns, :port, 5353)
@@ -56,7 +57,7 @@ defmodule Mdns.Client do
       multicast_loop: true,
       multicast_ttl: 32,
       reuseaddr: true
-    ]
+    ] ++ Network.reuse_port()
 
     {:ok, udp} = :gen_udp.open(@port, udp_options)
     {:reply, :ok, %State{state | udp: udp}}

--- a/lib/mdns/server.ex
+++ b/lib/mdns/server.ex
@@ -1,6 +1,7 @@
 defmodule Mdns.Server do
   use GenServer
   require Logger
+  alias Mdns.Utilities.Network
 
   @mdns_group {224, 0, 0, 251}
   @port Application.get_env(:mdns, :port, 5353)
@@ -63,7 +64,7 @@ defmodule Mdns.Server do
       multicast_loop: true,
       multicast_ttl: 255,
       reuseaddr: true
-    ]
+    ] ++ Network.reuse_port()
 
     {:ok, udp} = :gen_udp.open(@port, udp_options)
     {:reply, :ok, %State{state | udp: udp}}
@@ -99,7 +100,6 @@ defmodule Mdns.Server do
   end
 
   def handle_query(_ip, record, state) do
-    # Logger.debug("mDNS got query: #{inspect record}")
     Enum.flat_map(record.qdlist, fn %DNS.Query{} = q ->
       Enum.reduce(state.services, [], fn service, answers ->
         cond do

--- a/lib/utilities/network.ex
+++ b/lib/utilities/network.ex
@@ -3,6 +3,7 @@ defmodule Mdns.Utilities.Network do
   @sol_socket 0xFFFF
   @so_reuseport 0x0200
 
+  @spec reuse_port :: [{:raw, 65535, 512, <<_::32>>}]
   def reuse_port do
     case :os.type() do
       {:unix, os_name} ->
@@ -11,6 +12,14 @@ defmodule Mdns.Utilities.Network do
       _ ->
         []
     end
+  end
+
+  def mdns_port do
+    Application.get_env(:mdns, :port, 5353)
+  end
+
+  def mdns_group do
+    {224, 0, 0, 251}
   end
 
   defp unix_reuse_port(os_name) when os_name in [:darwin, :freebsd, :openbsd, :netbsd],

--- a/lib/utilities/network.ex
+++ b/lib/utilities/network.ex
@@ -1,0 +1,20 @@
+defmodule Mdns.Utilities.Network do
+
+  @sol_socket 0xFFFF
+  @so_reuseport 0x0200
+
+  def reuse_port do
+    case :os.type() do
+      {:unix, os_name} ->
+        unix_reuse_port(os_name)
+
+      _ ->
+        []
+    end
+  end
+
+  defp unix_reuse_port(os_name) when os_name in [:darwin, :freebsd, :openbsd, :netbsd],
+    do: [{:raw, @sol_socket, @so_reuseport, <<1::native-32>>}]
+
+  defp unix_reuse_port(_), do: []
+end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,6 @@
-%{"dns": {:hex, :dns, "2.0.0", "701cc7bde399565b7aa16813cca7b7bb079c80b3bd846363b581ba45a04d8262", [:mix], [{:socket, "~> 0.3.13", [hex: :socket, repo: "hexpm", optional: false]}], "hexpm"},
-  "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.18.2", "993e0a95e9fbb790ac54ea58e700b45b299bd48bc44b4ae0404f28161f37a83e", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "socket": {:hex, :socket, "0.3.13", "98a2ab20ce17f95fb512c5cadddba32b57273e0d2dba2d2e5f976c5969d0c632", [:mix], [], "hexpm"}}
+%{
+  "dns": {:hex, :dns, "2.0.0", "701cc7bde399565b7aa16813cca7b7bb079c80b3bd846363b581ba45a04d8262", [:mix], [{:socket, "~> 0.3.13", [hex: :socket, repo: "hexpm", optional: false]}], "hexpm", "47146d1157d7a6763f9e9dcfdaddbabb9fdb1c36881efa45c6a47ed11a08a0fb"},
+  "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm", "1b34655872366414f69dd987cb121c049f76984b6ac69f52fff6d8fd64d29cfd"},
+  "ex_doc": {:hex, :ex_doc, "0.18.2", "993e0a95e9fbb790ac54ea58e700b45b299bd48bc44b4ae0404f28161f37a83e", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm", "eacdfd22d5c7e5f3fda086214c69a8b6ca4298ad90d99f399d591f14eead6a61"},
+  "socket": {:hex, :socket, "0.3.13", "98a2ab20ce17f95fb512c5cadddba32b57273e0d2dba2d2e5f976c5969d0c632", [:mix], [], "hexpm", "f82ea9833ef49dde272e6568ab8aac657a636acb4cf44a7de8a935acb8957c2e"},
+}


### PR DESCRIPTION
Add the support to reuse udp ports on distros based on darwin, freebsd,
openbsd, and netbsd. This will allow to test the solution on systems
that already have mdns servers like macOS.