### PR TITLE
RFC 6762 6.7 Legacy Unicast Responses Compliance

### DIFF
--- a/lib/utilities/network.ex
+++ b/lib/utilities/network.ex
@@ -14,13 +14,9 @@ defmodule Mdns.Utilities.Network do
     end
   end
 
-  def mdns_port do
-    Application.get_env(:mdns, :port, 5353)
-  end
+  def mdns_port, do: Application.get_env(:mdns, :port, 5353)
 
-  def mdns_group do
-    {224, 0, 0, 251}
-  end
+  def mdns_group, do: {224, 0, 0, 251}
 
   defp unix_reuse_port(os_name) when os_name in [:darwin, :freebsd, :openbsd, :netbsd],
     do: [{:raw, @sol_socket, @so_reuseport, <<1::native-32>>}]


### PR DESCRIPTION
According to RFC 6762, section 6,7

"If the source UDP port in a received Multicast DNS query is not port
5353, this indicates that the querier originating the query is a
simple resolver such as described in Section 5.1, "One-Shot Multicast
DNS Queries", which does not fully implement all of Multicast DNS.
In this case, the Multicast DNS responder MUST send a UDP response
directly back to the querier, via unicast, to the query packet's
source IP address and port.  This unicast response MUST be a
conventional unicast response as would be generated by a conventional
Unicast DNS server; for example, it MUST repeat the query ID and the
question given in the query message."

This commit will add the header id of the original query to the
response and decide the ip and port to return the mDNS response to.

If the origin port is 5353, then the response will be to the
multicast ip and port (224.0.0.251:5353). If not, the code will respect
the original ip and port given that querier does not fully implement
all of Multicast DNS.