### PR TITLE
Update network utilites for Windows and Linux

### DIFF
--- a/lib/utilities/network.ex
+++ b/lib/utilities/network.ex
@@ -1,13 +1,19 @@
 defmodule Mdns.Utilities.Network do
-
   @sol_socket 0xFFFF
   @so_reuseport 0x0200
+  @so_reuseaddr 0x0004
 
-  @spec reuse_port :: [{:raw, 65535, 512, <<_::32>>}]
+  @spec reuse_port :: [{:raw, 65535, 512 | 4, <<_::32>>}]
   def reuse_port do
     case :os.type() do
-      {:unix, os_name} ->
-        unix_reuse_port(os_name)
+      {:unix, :linux} ->
+        reuse_port_linux()
+
+      {:unix, os_name} when os_name in [:darwin, :freebsd, :openbsd, :netbsd] ->
+        get_reuse_port()
+
+      {:win32, _unused} ->
+        get_reuse_address()
 
       _ ->
         []
@@ -18,8 +24,17 @@ defmodule Mdns.Utilities.Network do
 
   def mdns_group, do: {224, 0, 0, 251}
 
-  defp unix_reuse_port(os_name) when os_name in [:darwin, :freebsd, :openbsd, :netbsd],
-    do: [{:raw, @sol_socket, @so_reuseport, <<1::native-32>>}]
+  defp reuse_port_linux() do
+    case :os.version() do
+      {major, minor, _} when major > 3 or (major == 3 and minor >= 9) ->
+        get_reuse_port()
 
-  defp unix_reuse_port(_), do: []
+      _before_3_9 ->
+        get_reuse_address()
+    end
+  end
+
+  defp get_reuse_port(), do: [{:raw, @sol_socket, @so_reuseport, <<1::native-32>>}]
+
+  defp get_reuse_address(), do: [{:raw, @sol_socket, @so_reuseaddr, <<1::native-32>>}]
 end


### PR DESCRIPTION
Add OS-specific port reuse handling for Windows sockets and for Linux.

This avoids `:eaddrinuse` errors that occurred nearly all the time in Windows, and sometimes in Linux.
Note: Linux Kernel supports SO_REUSEPORT starting in 3.9, so different options are used depending on the kernel version.