### PR TITLE
Fix handle dns resource opt

### DIFF
--- a/lib/mdns/client.ex
+++ b/lib/mdns/client.ex
@@ -157,6 +157,10 @@ defmodule Mdns.Client do
     device
   end
 
+  def handle_device(%DNS.ResourceOpt{}, device) do
+    device
+  end
+
   def handle_device({:dns_rr, _, _, _, _, _, _, _, _, _}, device) do
     device
   end

--- a/lib/mdns/client.ex
+++ b/lib/mdns/client.ex
@@ -22,7 +22,7 @@ defmodule Mdns.Client do
               payload: %{}
   end
 
-  def start_link do
+  def start_link(_) do
     GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
   end
 

--- a/lib/mdns/event_manager.ex
+++ b/lib/mdns/event_manager.ex
@@ -14,7 +14,7 @@ defmodule Mdns.EventManager do
     GenServer.call(__MODULE__, {:notify, message})
   end
 
-  def start_link do
+  def start_link(_) do
     GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
   end
 

--- a/lib/mdns/server.ex
+++ b/lib/mdns/server.ex
@@ -26,7 +26,7 @@ defmodule Mdns.Server do
               type: :ptr
   end
 
-  def start_link do
+  def start_link(_) do
     GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
   end
 

--- a/lib/mdns/supervisor.ex
+++ b/lib/mdns/supervisor.ex
@@ -7,12 +7,12 @@ defmodule Mdns.Supervisor do
 
   def init(:ok) do
     children = [
-      supervisor(Registry, [:duplicate, Mdns.EventManager.Registry, []]),
-      worker(Mdns.EventManager, []),
-      worker(Mdns.Client, []),
-      worker(Mdns.Server, [])
+      {Registry, keys: :duplicate, name: Mdns.EventManager.Registry},
+      Mdns.EventManager,
+      Mdns.Client,
+      Mdns.Server
     ]
 
-    supervise(children, strategy: :one_for_one)
+    Supervisor.init(children, strategy: :one_for_one)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -41,6 +41,6 @@ defmodule Mdns.Mixfile do
   end
 
   defp deps do
-    [{:dns, "~> 2.0"}, {:ex_doc, ">= 0.0.0", only: :dev}]
+    [{:dns, "~> 2.2"}, {:ex_doc, ">= 0.0.0", only: :dev}]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,36 +1,10 @@
 %{
-  dns:
-    {:hex, :dns, "2.0.0", "701cc7bde399565b7aa16813cca7b7bb079c80b3bd846363b581ba45a04d8262",
-     [:mix], [{:socket, "~> 0.3.13", [hex: :socket, repo: "hexpm", optional: false]}], "hexpm",
-     "47146d1157d7a6763f9e9dcfdaddbabb9fdb1c36881efa45c6a47ed11a08a0fb"},
-  earmark:
-    {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439",
-     [:mix], [], "hexpm", "1b34655872366414f69dd987cb121c049f76984b6ac69f52fff6d8fd64d29cfd"},
-  earmark_parser:
-    {:hex, :earmark_parser, "1.4.10",
-     "6603d7a603b9c18d3d20db69921527f82ef09990885ed7525003c7fe7dc86c56", [:mix], [], "hexpm",
-     "8e2d5370b732385db2c9b22215c3f59c84ac7dda7ed7e544d7c459496ae519c0"},
-  ex_doc:
-    {:hex, :ex_doc, "0.22.2", "03a2a58bdd2ba0d83d004507c4ee113b9c521956938298eba16e55cc4aba4a6c",
-     [:mix],
-     [
-       {:earmark_parser, "~> 1.4.0", [hex: :earmark_parser, repo: "hexpm", optional: false]},
-       {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}
-     ], "hexpm", "cf60e1b3e2efe317095b6bb79651f83a2c1b3edcb4d319c421d7fcda8b3aff26"},
-  makeup:
-    {:hex, :makeup, "1.0.3", "e339e2f766d12e7260e6672dd4047405963c5ec99661abdc432e6ec67d29ef95",
-     [:mix], [{:nimble_parsec, "~> 0.5", [hex: :nimble_parsec, repo: "hexpm", optional: false]}],
-     "hexpm", "2e9b4996d11832947731f7608fed7ad2f9443011b3b479ae288011265cdd3dad"},
-  makeup_elixir:
-    {:hex, :makeup_elixir, "0.14.1",
-     "4f0e96847c63c17841d42c08107405a005a2680eb9c7ccadfd757bd31dabccfb", [:mix],
-     [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm",
-     "f2438b1a80eaec9ede832b5c41cd4f373b38fd7aa33e3b22d9db79e640cbde11"},
-  nimble_parsec:
-    {:hex, :nimble_parsec, "0.6.0",
-     "32111b3bf39137144abd7ba1cce0914533b2d16ef35e8abc5ec8be6122944263", [:mix], [], "hexpm",
-     "27eac315a94909d4dc68bc07a4a83e06c8379237c5ea528a9acff4ca1c873c52"},
-  socket:
-    {:hex, :socket, "0.3.13", "98a2ab20ce17f95fb512c5cadddba32b57273e0d2dba2d2e5f976c5969d0c632",
-     [:mix], [], "hexpm", "f82ea9833ef49dde272e6568ab8aac657a636acb4cf44a7de8a935acb8957c2e"}
+  "dns": {:hex, :dns, "2.2.0", "4721a79c2bccc25481930dffbfd06f40851321c3d679986af307111214bf124c", [:mix], [{:socket, "~> 0.3.13", [hex: :socket, repo: "hexpm", optional: false]}], "hexpm", "13ed1ef36ce896211ec6ce5e02709dbfb12aa61d6255bda8d531577a0a5a56e0"},
+  "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm", "1b34655872366414f69dd987cb121c049f76984b6ac69f52fff6d8fd64d29cfd"},
+  "earmark_parser": {:hex, :earmark_parser, "1.4.10", "6603d7a603b9c18d3d20db69921527f82ef09990885ed7525003c7fe7dc86c56", [:mix], [], "hexpm", "8e2d5370b732385db2c9b22215c3f59c84ac7dda7ed7e544d7c459496ae519c0"},
+  "ex_doc": {:hex, :ex_doc, "0.22.2", "03a2a58bdd2ba0d83d004507c4ee113b9c521956938298eba16e55cc4aba4a6c", [:mix], [{:earmark_parser, "~> 1.4.0", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm", "cf60e1b3e2efe317095b6bb79651f83a2c1b3edcb4d319c421d7fcda8b3aff26"},
+  "makeup": {:hex, :makeup, "1.0.3", "e339e2f766d12e7260e6672dd4047405963c5ec99661abdc432e6ec67d29ef95", [:mix], [{:nimble_parsec, "~> 0.5", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "2e9b4996d11832947731f7608fed7ad2f9443011b3b479ae288011265cdd3dad"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.14.1", "4f0e96847c63c17841d42c08107405a005a2680eb9c7ccadfd757bd31dabccfb", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "f2438b1a80eaec9ede832b5c41cd4f373b38fd7aa33e3b22d9db79e640cbde11"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.6.0", "32111b3bf39137144abd7ba1cce0914533b2d16ef35e8abc5ec8be6122944263", [:mix], [], "hexpm", "27eac315a94909d4dc68bc07a4a83e06c8379237c5ea528a9acff4ca1c873c52"},
+  "socket": {:hex, :socket, "0.3.13", "98a2ab20ce17f95fb512c5cadddba32b57273e0d2dba2d2e5f976c5969d0c632", [:mix], [], "hexpm", "f82ea9833ef49dde272e6568ab8aac657a636acb4cf44a7de8a935acb8957c2e"},
 }


### PR DESCRIPTION
This PR fixes an issue with the new version of the `dns` lib 2.2, which now transforms the `dns_rr_opt` record into a `DNS.ResourceOpt` struct. There was a missing function clause to handle this new struct.

Also fixed compilation warnings due to use of functions of the deprecated module Supervisor.Spec with the new child spec definition.
