### PR TITLE
add support for the port field in SRV resources

### DIFF
--- a/lib/mdns/client.ex
+++ b/lib/mdns/client.ex
@@ -17,6 +17,7 @@ defmodule Mdns.Client do
 
   defmodule Device do
     defstruct ip: nil,
+              port: nil,
               services: [],
               domain: nil,
               payload: %{}
@@ -150,6 +151,13 @@ defmodule Mdns.Client do
               _ -> nil
             end
           end)
+    }
+  end
+
+  def handle_device(%DNS.Resource{:type => :srv, data: {_priority, _weight, port, _target}}, device) do
+    %Device{
+      device
+      | :port => port
     }
   end
 


### PR DESCRIPTION
This adds a new field to the Device struct that contains the `port` of
the service. This field defaults to `nil` but will be updated when it
receives the appropriate response.

to do this, a new `handle_device` is added to handle `:srv` type
resources. I opted to not include priority or weight fields as described
in the RFC since I'm not using them and have no way to test this, but
the variables have placeholders in case a future developer wants to
include this.